### PR TITLE
Remove blank unsafe import

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	_ "unsafe"
-
 	"tapir-cli/cmd"
 )
 


### PR DESCRIPTION
Not sure why this is here but things seem to build fine without it.