### PR TITLE
avoid hardcoded cert/key names

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,12 +140,13 @@ func RootInitConfig() {
 
 	if tapir.GlobalCF.UseTLS { // default = true
 		cd := viper.GetString("certs.certdir")
+        key := viper.GetString("certs.tapir-cli.key")
+        cert := viper.GetString("certs.tapir-cli.cert")
 		if cd == "" {
 			log.Fatalf("Error: missing config key: certs.certdir")
 		}
-		cert := cd + "/" + certname
 		tlsConfig, err := tapir.NewClientConfig(viper.GetString("certs.cacertfile"),
-			cert+".key", cert+".crt")
+			key, cert)
 		if err != nil {
 			log.Fatalf("Error: Could not set up TLS: %v", err)
 		}

--- a/cmd/slogger.go
+++ b/cmd/slogger.go
@@ -180,12 +180,13 @@ func SloggerApi() (*tapir.ApiClient, error) {
 
 	if tapir.GlobalCF.UseTLS { // default = true
 		cd := viper.GetString("certs.certdir")
+        key := viper.GetString("certs.tapir-cli.key")
+        cert := viper.GetString("certs.tapir-cli.cert")
 		if cd == "" {
 			return nil, fmt.Errorf("Error: missing config key: certs.certdir")
 		}
-		cert := cd + "/" + certname
 		tlsConfig, err := tapir.NewClientConfig(viper.GetString("certs.cacertfile"),
-			cert+".key", cert+".crt")
+			key, cert)
 		if err != nil {
 			return nil, fmt.Errorf("Error: Could not set up TLS: %v", err)
 		}


### PR DESCRIPTION
Borde vi ha denna på main? Kanske pajjar folks befintliga setuper, men det känns iaf som att filnamnen inte borde vara hårdkodade.