### PR TITLE
Added missing files for deb package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,21 +29,8 @@ tapir-cli
 dnstapir-cli
 version.go
 
-# Ignore rpm build directory and related stuff
-*.tar.gz
-*.src.rpm
-#rpm/
-#!rpm/SOURCES/tapir-renew.service
-#!rpm/SOURCES/tapir-renew.timer
-#!rpm/SOURCES/tapir-cli.yaml
-#!rpm/SPECS/tapir-cli.spec
-
-# Ignore deb build directory and related stuff
-*.deb
-deb/
-!deb/DEBIAN/control.in
-!deb/DEBIAN/postinst
-!deb/DEBIAN/postrm
-
 # Ignore built stuff
 out/
+*.tar.gz
+*.rpm
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ srpm: tarball
 	test -z "$(outdir)" || cp $(OUT)/$(PROG)-$(RPM_VERSION)-*.src.rpm "$(outdir)"
 
 rpm: srpm
-	rpmbuild --rebuild --define "%_topdir $(OUT)/rpm" --undefine=dist $(OUT)/$(PROG)-$(RPM_VERSION)-*.rpm
-	cp $(OUT)/rpm/RPMS/**/$(PROG)-$(RPM_VERSION)-*.rpm $(OUT)
+	rpmbuild --rebuild --define "%_topdir $(OUT)/rpm" --undefine=dist $(OUT)/$(PROG)-$(RPM_VERSION)-*.src.rpm
+	cp $(OUT)/rpm/RPMS/*/$(PROG)-$(RPM_VERSION)-*.rpm $(OUT)
 	test -z "$(outdir)" || cp $(OUT)/$(PROG)-$(RPM_VERSION)-*.rpm "$(outdir)"
 
 deb: build

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,14 @@ srpm: tarball
 	test -z "$(outdir)" || cp $(OUT)/$(PROG)-$(RPM_VERSION)-*.src.rpm "$(outdir)"
 
 rpm: srpm
-	rpmbuild --recompile --define "%_topdir $(OUT)/rpm" --undefine=dist $(OUT)/$(PROG)-$(RPM_VERSION)-*.src.rpm
+	rpmbuild --rebuild --define "%_topdir $(OUT)/rpm" --undefine=dist $(OUT)/$(PROG)-$(RPM_VERSION)-*.rpm
+	cp $(OUT)/rpm/RPMS/**/$(PROG)-$(RPM_VERSION)-*.rpm $(OUT)
+	test -z "$(outdir)" || cp $(OUT)/$(PROG)-$(RPM_VERSION)-*.rpm "$(outdir)"
 
 deb: build
 	cp -r deb $(OUT)
 	mkdir -p $(OUT)/deb/usr/bin
 	mkdir -p $(OUT)/deb/etc/dnstapir/certs
-	mkdir -p $(OUT)/deb/usr/lib/systemd/system
 	cp $(OUT)/$(PROG) $(OUT)/deb/usr/bin
 	sed -e "s/@@VERSION@@/$(DEB_VERSION)/g" $(OUT)/deb/DEBIAN/control.in > $(OUT)/deb/DEBIAN/control
 	dpkg-deb -b $(OUT)/deb/ $(OUT)/$(PROG)-$(DEB_VERSION).deb

--- a/deb/DEBIAN/postrm
+++ b/deb/DEBIAN/postrm
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+    remove)
+        ;;
+    purge)
+        rm -rf /etc/dnstapir/
+        ;;
+esac

--- a/deb/usr/lib/systemd/system/dnstapir-renew.service
+++ b/deb/usr/lib/systemd/system/dnstapir-renew.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=DNS TAPIR Edge Certificate Renewal
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=dnstapir-renew
+Group=dnstapir
+ExecStart=/usr/bin/dnstapir-cli --standalone renew \
+    --renew-datakey /etc/dnstapir/certs/datakey-priv.json \
+    --renew-cacert-out /etc/dnstapir/certs/ca.crt \
+    --renew-clientkey /etc/dnstapir/certs/tls.key \
+    --renew-clientcert-out /etc/dnstapir/certs/tls.crt

--- a/deb/usr/lib/systemd/system/dnstapir-renew.timer
+++ b/deb/usr/lib/systemd/system/dnstapir-renew.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Renew DNS TAPIR mTLS certificate every week
+ConditionPathExists=/etc/dnstapir/certs/datakey-priv.json
+ConditionPathExists=/etc/dnstapir/certs/ca.crt
+ConditionPathExists=/etc/dnstapir/certs/tls.key
+ConditionPathExists=/etc/dnstapir/certs/tls.crt
+
+[Timer]
+OnCalendar=weekly
+AccuracySec=1h
+RandomizedDelaySec=100min
+
+[Install]
+WantedBy=timers.target

--- a/rpm/SOURCES/dnstapir-renew.sysusers.conf
+++ b/rpm/SOURCES/dnstapir-renew.sysusers.conf
@@ -1,3 +1,3 @@
 #Type Name          ID  GECOS                           Home directory  Shell
-u     dnstapir-renew  -   "DNS TAPIR Edge Certificate Renewal"    /etc/dnstapir   -
+u     dnstapir-renew  -:dnstapir   "DNS TAPIR Edge Certificate Renewal"    /etc/dnstapir   -
 g     dnstapir      -

--- a/rpm/SOURCES/dnstapir-renew.sysusers.conf
+++ b/rpm/SOURCES/dnstapir-renew.sysusers.conf
@@ -1,0 +1,3 @@
+#Type Name          ID  GECOS                           Home directory  Shell
+u     dnstapir-renew  -   "DNS TAPIR Edge Certificate Renewal"    /etc/dnstapir   -
+g     dnstapir      -

--- a/rpm/SPECS/dnstapir-cli.spec.in
+++ b/rpm/SPECS/dnstapir-cli.spec.in
@@ -22,6 +22,12 @@ Source3:       dnstapir-renew.sysusers.conf
 BuildRequires: git
 BuildRequires: golang
 
+%if %{with sysusers_compat} && 0%{?suse_version}
+Provides: user(dnstapir-renew)
+Provides: group(dnstapir)
+%endif
+
+
 %description
 DNS TAPIR EDGE ClI Tool for managing an EDGE deployment
 

--- a/rpm/SPECS/dnstapir-cli.spec.in
+++ b/rpm/SPECS/dnstapir-cli.spec.in
@@ -31,8 +31,8 @@ Provides: group(dnstapir)
 %description
 DNS TAPIR EDGE ClI Tool for managing an EDGE deployment
 
-%{!?_unitdir: %define _unitdir /usr/lib/systemd/system/}
-%{!?_sysusersdir: %define _sysusersdir /usr/lib/sysusers.d/}
+%{!?_unitdir: %define _unitdir /usr/lib/systemd/system}
+%{!?_sysusersdir: %define _sysusersdir /usr/lib/sysusers.d}
 
 %prep
 %setup -n %{name}

--- a/rpm/SPECS/dnstapir-cli.spec.in
+++ b/rpm/SPECS/dnstapir-cli.spec.in
@@ -2,7 +2,7 @@
 %global debug_package %{nil}
 
 # Handle backwards compat for sysuser creation
-%if 0%{?fedora} < 42 || (0%{?rhel} && 0%{?rhel} <= 10) || (0%{?mageia} && 0%{?mageia} < 10) || (0%{?suse_version} && 0%{?suse_version} < 1660)
+%if (0%{?fedora} && 0%{?fedora} < 42) || (0%{?rhel} && 0%{?rhel} <= 10) || (0%{?suse_version} && 0%{?suse_version} < 1660)
 %bcond_without sysusers_compat
 %else
 %bcond_with sysusers_compat
@@ -60,7 +60,7 @@ install -m 0644 -D %{SOURCE3} %{buildroot}%{_sysusersdir}/dnstapir-renew.conf
 %attr(0660,-,dnstapir) %ghost %{_sysconfdir}/dnstapir/dnstapir-cli.yaml
 %attr(0644,root,dnstapir) %{_unitdir}/dnstapir-renew.service
 %attr(0644,root,dnstapir) %{_unitdir}/dnstapir-renew.timer
-%{_sysusersdir}/dnstapir-renew.conf
+%attr(0644,root,root) %{_sysusersdir}/dnstapir-renew.conf
 
 %if %{with sysusers_compat}
 %pre

--- a/rpm/SPECS/dnstapir-cli.spec.in
+++ b/rpm/SPECS/dnstapir-cli.spec.in
@@ -1,6 +1,13 @@
 # Disable building of debug packages
 %global debug_package %{nil}
 
+# Handle backwards compat for sysuser creation
+%if 0%{?fedora} < 42 || (0%{?rhel} && 0%{?rhel} <= 10) || (0%{?mageia} && 0%{?mageia} < 10) || (0%{?suse_version} && 0%{?suse_version} < 1660)
+%bcond_without sysusers_compat
+%else
+%bcond_with sysusers_compat
+%endif
+
 Name:          dnstapir-cli
 Version:       @@VERSION@@
 Release:       1%{?dist}
@@ -11,6 +18,7 @@ URL:           https://www.github.com/dnstapir/cli
 Source0:       %{name}.tar.gz
 Source1:       dnstapir-renew.service
 Source2:       dnstapir-renew.timer
+Source3:       dnstapir-renew.sysusers.conf
 BuildRequires: git
 BuildRequires: golang
 
@@ -35,6 +43,10 @@ DESTDIR=%{buildroot}%{_bindir} make install
 install -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}
 install -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}
 
+# Users and Groups
+install -m 0644 -D %{SOURCE3} %{buildroot}%{_sysusersdir}/dnstapir-renew.conf
+
+
 %files
 %attr(0770,root,dnstapir) %dir %{_sysconfdir}/dnstapir
 %attr(0770,root,dnstapir) %dir %{_sysconfdir}/dnstapir/certs
@@ -42,10 +54,13 @@ install -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}
 %attr(0660,-,dnstapir) %ghost %{_sysconfdir}/dnstapir/dnstapir-cli.yaml
 %attr(0644,root,dnstapir) %{_unitdir}/dnstapir-renew.service
 %attr(0644,root,dnstapir) %{_unitdir}/dnstapir-renew.timer
+%{_sysusersdir}/dnstapir-renew.conf
 
+%if %{with sysusers_compat}
 %pre
 /usr/bin/getent group dnstapir || /usr/sbin/groupadd -r dnstapir
 /usr/bin/getent passwd dnstapir-renew || /usr/sbin/useradd -r -d /etc/dnstapir -G dnstapir -s /sbin/nologin dnstapir-renew
+%endif
 
 %post
 


### PR DESCRIPTION
Declarative sysusers setup in rpm package
Minor fixes to rpm and deb service unit files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automated weekly certificate renewal service and timer for DNS TAPIR Edge with prechecks and a oneshot renewal command.
  * Installs a dedicated renewal user and group to run renewal tasks, with a compatibility toggle for older distributions.

* **Chores**
  * Standardized ignore rules for built artifacts and streamlined build output handling (RPMs copied to output when built).
  * Package removal now purges configuration on full uninstall.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->